### PR TITLE
Add workflow to generate Release PDF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+# This file generated from a template file maintained in the ivoatex repository.
+# To create and install it into a project repository, do:
+#    make github-preview
+#    git commit
+#    git push
+#
+name: Update PDF Release
+
+defaults:
+  run:
+    shell: bash
+    working-directory: doc
+
+env:
+  doc_name: Coordinates
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - name: Checkout the repository
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    
+    - name: Setup dependencies
+      run: |
+        sudo apt update
+        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
+        sudo snap install pdftk
+    
+    - name: Build the document
+      run: make ${{ env.doc_name }}.pdf
+    
+    - name: Check the output
+      run: |
+        test -f ${{ env.doc_name }}.pdf
+        test -f ${{ env.doc_name }}.bbl
+    
+    - name: Move the auto-pdf-stable tag
+      uses: weareyipyip/walking-tag-action@v2
+      with:
+        tag-name: auto-pdf-stable
+        tag-message: |
+          Last commit taken into account for the automatically updated PDF of this IVOA document.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Update the PDF 
+      uses: Xotl/cool-github-releases@v1
+      with:
+        mode: update
+        isPrerelease: false
+        tag_name: auto-pdf-stable
+        release_name: "Auto PDF Release"
+        body_mrkdwn: |
+          This provides a PDF of the tagged release ${{ github.event.release.tag_name }} of this repository.
+          It will be updated automatically on Release operations.
+          _Corresponding commit: ${{ github.sha }}_
+        assets: doc/${{ env.doc_name }}.pdf
+        replace_assets: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Update PDF Preview](https://github.com/mcdittmar/CoordinateDM/actions/workflows/preview.yml/badge.svg)](https://github.com/mcdittmar/CoordinateDM/actions/workflows/preview.yml)
-[![PDF-Preview](https://img.shields.io/badge/PDF-Preview-blue)](https://github.com/mcdittmar/CoordinateDM/releases/download/auto-pdf-preview/Coordinates-draft.pdf)
+[![PDF-Release](https://img.shields.io/badge/PDF-Release-green)](https://github.com/ivoa-std/CoordinateDM/releases/download/auto-pdf-stabke/Coordinates.pdf)
+[![PDF-Preview](https://img.shields.io/badge/PDF-Preview-blue)](https://github.com/ivoa-std/CoordinateDM/releases/download/auto-pdf-preview/Coordinates-draft.pdf)
 
 # What is it?
 IVOA Data Model for Astronomical Coordinates and Systems, covering the following concepts:
@@ -14,7 +14,7 @@ IVOA Data Model for Astronomical Coordinates and Systems, covering the following
 
 
 # Status
-Latest stable version is [WD-1.0](https://www.ivoa.net/documents/Coords/20200310/index.html)
+Latest stable version is [PR-1.0](https://www.ivoa.net/documents/Coords/20200310/index.html)
 
 
 # License


### PR DESCRIPTION
Adds a new workflow which triggers off Release, that generates a non-draft version of the PDF document
The PDF is stored under the tag 'auto-pdf-stable' (similar to the preview PDF).

Added a button to the README.md file which points to this 'most current released version' of the document.