### PR TITLE
Resolve issue #8: typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,17 @@
 # Project specific excludes
 #
 #
-# Binaries
+# ivoatex intermediate files
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.pdf
+*.toc
+ivoatexmeta.tex
 
 # vo-dml products
 *.cmap

--- a/doc/Coordinates.tex
+++ b/doc/Coordinates.tex
@@ -120,7 +120,7 @@ which must be met to facilitate these various usage threads.
        \begin{itemize}
           \item dimensionality (typically 1,2 or 3 for physical domain), pixel domain may be of any dimension
           \item axis configuration (for spatial domain which has >1D).  The most common configurations for astronomical data are Cartesian and Spherical, but others may be used as well.
-          \item domain range along each axis, typically +/- Inf, but may be limited due to physical constraints (e.g. physical size of a detector, sensitivity limitiations, etc)
+          \item domain range along each axis, typically +/- Inf, but may be limited due to physical constraints (e.g. physical size of a detector, sensitivity limitations, etc)
           \item association with additional metadata further describing the nature of the domain space ( Frame ).  This is especially true for the Spatial and Temporal domains, but may apply to others as well.  Examples include:
           \begin{itemize}
              \item reference position (location of origin)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ DOCNAME = Coordinates
 DOCVERSION = 1.0
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2021-09-24
+DOCDATE = 2022-05-17
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PR

--- a/doc/body.tex
+++ b/doc/body.tex
@@ -166,7 +166,7 @@
      * Provide the time scale used (e.g. TT, TDB, TAI, GPS, ET, UTC, TCG, TCB). \newline
      * Provide the reference position (place where the time is measured).
     \item  Note the following:  \newline
-     * JD and MJD are dimensionless, though a unit of 'day' is implied.  \newline
+     * The unit of both JD and MJD (day) is implicit.  \newline
      * JD and MJD do not imply a time scale; it needs to be provided separately.  \newline
      * JD and MJD are not recommended for expressing times in UTC since not all UTC days are the same length.  Instead, UTC times are best expressed as a formatted string such as the ISOTime type described in Section \ref{sect:ISOTime}. \newline
      * TDB runs on average synchronously with TT, but corrects for the relativistic effects caused by deviations in the orbit of the Earth from perfect circularity and constant gravitational potential. \newline

--- a/doc/body.tex
+++ b/doc/body.tex
@@ -166,9 +166,9 @@
      * Provide the time scale used (e.g. TT, TDB, TAI, GPS, ET, UTC, TCG, TCB). \newline
      * Provide the reference position (place where the time is measured).
     \item  Note the following:  \newline
-     * JD and MJD do not imply a time scale; it needs to be provided separately.  \newline
      * JD and MJD are dimensionless, though a unit of 'day' is implied.  \newline
-     * It is a bad idea to mix UTC with JD or MJD, since not all UTC days are the same length. Instead, use the restricted form of ISO-8601: [[+|-]c]ccyy-mm-dd[Thh[:mm[:ss[.ss...]]]], with no time zone characters. \newline
+     * JD and MJD do not imply a time scale; it needs to be provided separately.  \newline
+     * JD and MJD are not recommended for expressing times in UTC since not all UTC days are the same length.  Instead, UTC times are best expressed as a formatted string such as the ISOTime type described in Section \ref{sect:ISOTime}. \newline
      * TDB runs on average synchronously with TT, but corrects for the relativistic effects caused by deviations in the orbit of the Earth from perfect circularity and constant gravitational potential. \newline
     \item Recommendations:  \newline
      * Avoid UTC. It is trivial to convert the times provided by, e.g., space agencies, to TT immediately when you get them, and it will save headaches later on.  \newline
@@ -183,7 +183,7 @@
     \item What if you deal with incomplete data?  \newline
      * If you do not know the time scale and/or reference position, you can provide them as UNKNOWN and set the systematic error/uncertainty to, say, 1000 s. 100 s will do if only the time scale is unknown.
     \item What else is there to know?  \newline
-     * Quite a lot, especially the so-called coordinate time scales (TCG and TCB). Because TDB runs, on average, synchronously with TT, but in a very different potential well, which requires different values for fundamental physical constants in the barycenter. That is awkward and the coordinate time scales fix that by running at different rates. More in the above cited A\&A paper.\newline
+     * Quite a lot! Complete and accurate Time metadata is extremely important for many IVOA use cases. We strongly encourage a review of the above cited FITS WCS paper when describing temporal data.\newline
     \end{enumerate}
 
     \noindent \textbf{subset} \newline


### PR DESCRIPTION
Ancillary:
   * update to .gitignore file to include ivoatex files which should not be committed.
   * update document date in Makefile

Issue #8
   * Typos noted in #8 corrected
   * item re: architecture diagram missing is a PDF generation issue.. will be sure the next version going to the ivoa doc repository includes the architecture diagram.

Issue #9
   *  small updates to 2 segments of "TimeStamp" content.
